### PR TITLE
セットアップスクリプトの修正

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,13 @@
 echo ".devcontainer" >> .gitignore
 echo ".vscode" >> .gitignore
-echo "setup.sh" >> .gitignore
 
 export $(cat .env)
 rm .env
+rm setup.sh
 
-grep -l 'base' Cargo.toml .vscode/launch.json  | xargs sed -i "s/base/${PACKAGE_NAME}/g"
+grep -l 'base' Cargo.toml .vscode/launch.json  | xargs sed -i "" "s/base/${PACKAGE_NAME}/g"
+
+cargo update
 
 git add .
-git commit
+git commit -m "initial commit"


### PR DESCRIPTION
- このスクリプトが実行後不要になるので削除
- sedの引数がないとmac ではエラーになる
- `$cargo update`をしないとCargo.lockが更新されない
- commitメッセージは自明なので入力を省略